### PR TITLE
Add Darwin module

### DIFF
--- a/darwin/module.nix
+++ b/darwin/module.nix
@@ -1,0 +1,50 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.angrr;
+in
+{
+  imports = [ ../shared/options.nix ];
+  options = {
+    services.angrr.timer = {
+      enable = lib.mkEnableOption "angrr timer";
+      dates = lib.mkOption {
+        type = with lib.types; listOf (attrsOf int);
+        default = [
+          {
+            Hour = 3;
+            Minute = 0;
+          }
+        ];
+        description = ''
+          How often or when the retention policy is performed.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        launchd.daemons.angrr = {
+          script = ''
+            ${cfg.package}/bin/angrr run \
+              --log-level "${cfg.logLevel}" \
+              --period "${cfg.period}" \
+              ${lib.optionalString cfg.removeRoot "--remove-root"} \
+              --owned-only="${cfg.ownedOnly}" \
+              --no-prompt ${lib.escapeShellArgs cfg.extraArgs}
+          '';
+          serviceConfig.RunAtLoad = false;
+        };
+      }
+
+      (lib.mkIf cfg.timer.enable {
+        launchd.daemons.nix-gc.serviceConfig.StartCalendarInterval = cfg.timer.dates;
+      })
+    ]
+  );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
         systems = [
           "x86_64-linux"
           "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
         ];
         imports = [
           inputs.flake-parts.flakeModules.easyOverlay

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         ];
         flake = {
           nixosModules.angrr = ./nixos/module.nix;
+          darwinModules.angrr = ./darwin/module.nix;
         };
         perSystem =
           {

--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -1,6 +1,5 @@
 {
   config,
-  pkgs,
   lib,
   ...
 }:
@@ -8,10 +7,15 @@ let
   cfg = config.services.angrr;
 in
 {
+  imports = [ ../shared/options.nix ];
   options = {
     services.angrr = {
-      enable = lib.mkEnableOption "angrr";
-      package = lib.mkPackageOption pkgs "angrr" { };
+      enableNixGcIntegration = lib.mkOption {
+        type = with lib.types; bool;
+        description = ''
+          Whether to enable nix-gc.service integration
+        '';
+      };
       timer = {
         enable = lib.mkEnableOption "angrr timer";
         dates = lib.mkOption {
@@ -21,58 +25,6 @@ in
             How often or when the retention policy is performed.
           '';
         };
-      };
-      enableNixGcIntegration = lib.mkOption {
-        type = with lib.types; bool;
-        description = ''
-          Whether to enable nix-gc.service integration
-        '';
-      };
-      period = lib.mkOption {
-        type = with lib.types; str;
-        default = "7d";
-        example = "2weeks";
-        description = ''
-          The retention period of auto GC roots.
-        '';
-      };
-      removeRoot = lib.mkOption {
-        type = with lib.types; bool;
-        default = false;
-        description = ''
-          Whether to pass the `--remove-root` option to angrr.
-        '';
-      };
-      ownedOnly = lib.mkOption {
-        type = with lib.types; bool;
-        default = false;
-        description = ''
-          Control the `--remove-root=<true|false>` option of angrr.
-        '';
-        apply = b: if b then "true" else "false";
-      };
-      logLevel = lib.mkOption {
-        type =
-          with lib.types;
-          enum [
-            "off"
-            "error"
-            "warn"
-            "info"
-            "debug"
-            "trace"
-          ];
-        default = "info";
-        description = ''
-          Set the log level of angrr.
-        '';
-      };
-      extraArgs = lib.mkOption {
-        type = with lib.types; listOf str;
-        default = [ ];
-        description = ''
-          Extra command-line arguments pass to angrr.
-        '';
       };
     };
   };

--- a/shared/options.nix
+++ b/shared/options.nix
@@ -1,0 +1,55 @@
+{ lib, pkgs, ... }:
+{
+  options = {
+    services.angrr = {
+      enable = lib.mkEnableOption "angrr";
+      package = lib.mkPackageOption pkgs "angrr" { };
+      period = lib.mkOption {
+        type = with lib.types; str;
+        default = "7d";
+        example = "2weeks";
+        description = ''
+          The retention period of auto GC roots.
+        '';
+      };
+      removeRoot = lib.mkOption {
+        type = with lib.types; bool;
+        default = false;
+        description = ''
+          Whether to pass the `--remove-root` option to angrr.
+        '';
+      };
+      ownedOnly = lib.mkOption {
+        type = with lib.types; bool;
+        default = false;
+        description = ''
+          Control the `--remove-root=<true|false>` option of angrr.
+        '';
+        apply = b: if b then "true" else "false";
+      };
+      logLevel = lib.mkOption {
+        type =
+          with lib.types;
+          enum [
+            "off"
+            "error"
+            "warn"
+            "info"
+            "debug"
+            "trace"
+          ];
+        default = "info";
+        description = ''
+          Set the log level of angrr.
+        '';
+      };
+      extraArgs = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        description = ''
+          Extra command-line arguments pass to angrr.
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Extracted common module options to a new file.

Darwin version is missing a nix-gc compatibility option, but it seems as though launchd doesn't have any dependency-ordering logic.