### PR TITLE
Prepare for upstream

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -8,6 +8,8 @@ let
 in
 {
   imports = [ ../shared/options.nix ];
+  # disable upstream module
+  disabledModules = [ "services/misc/angrr.nix" ];
   options = {
     services.angrr = {
       enableNixGcIntegration = lib.mkOption {


### PR DESCRIPTION
Make the nixos module compatible with nixpkgs after <https://github.com/NixOS/nixpkgs/pull/439121>.