### PR TITLE
fix: prevent eval error

### DIFF
--- a/nixos/angrr.nix
+++ b/nixos/angrr.nix
@@ -270,6 +270,7 @@ in
       settings = lib.mkOption {
         type = lib.types.submodule settingsOptions;
         example = exampleSettings;
+        default = { };
         description = ''
           Global configuration for angrr in TOML format.
         '';


### PR DESCRIPTION
without this I get an error

```
       … while evaluating definitions from `/nix/store/24b29jfv23y9mh5ib7a5yljcgm0n65kw-source/nixos/modules/system/activation/top-level.nix':

       … while evaluating the option `system.systemBuilderArgs':

       … while evaluating definitions from `/nix/store/24b29jfv23y9mh5ib7a5yljcgm0n65kw-source/nixos/modules/system/activation/activatable-system.nix':

       … while evaluating the option `system.activationScripts.etc.text':

       … while evaluating definitions from `/nix/store/24b29jfv23y9mh5ib7a5yljcgm0n65kw-source/nixos/modules/system/etc/etc-activation.nix':

       … while evaluating definitions from `/nix/store/24b29jfv23y9mh5ib7a5yljcgm0n65kw-source/nixos/modules/system/etc/etc.nix':

       … while evaluating the option `environment.etc."angrr/config.toml".source':

       … while evaluating definitions from `/nix/store/52344r2j4q01psiqd28b35s78v45ygvr-source/nixos/angrr.nix':

       … while evaluating the option `services.angrr.configFile':

       … while evaluating the option `services.angrr.settings':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: The option `services.angrr.settings' was accessed but has no value defined. Try setting the option.
```