### PR TITLE
Implement "keep 1 generation every x interval for y times"

### DIFF
--- a/angrr/src/config.rs
+++ b/angrr/src/config.rs
@@ -225,15 +225,40 @@ pub struct ProfileConfig {
     /// Only useful for system profiles.
     #[serde(default)]
     pub keep_booted_system: bool,
+
+    /// Each rule retains `n` generations every `bucket-window` duration for `bucket-amount` buckets.
+    /// `n` defaults to 1.
+    #[serde(default)]
+    pub keep_n_per_bucket: Vec<KeepNPerBucket>,
+}
+
+const fn default_periodic_rule_n() -> usize {
+    1
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KeepNPerBucket {
+    #[serde(default = "default_periodic_rule_n")]
+    pub n: usize,
+
+    #[serde(with = "humantime_serde")]
+    #[serde(default)]
+    pub bucket_window: Duration,
+
+    #[serde(default)]
+    pub bucket_amount: u32,
 }
 
 impl ProfileConfig {
     fn validate(&self, name: &str) -> anyhow::Result<()> {
         if self.common.enable
-            && let (None, None) = (self.keep_since, self.keep_latest_n)
+            && self.keep_since.is_none()
+            && self.keep_latest_n.is_none()
+            && self.keep_n_per_bucket.is_empty()
         {
             anyhow::bail!(
-                "invalid profile policy {name}: at least one of keep-since and keep-latest-n must be set for the profile policy",
+                "invalid profile policy {name}: at least one of keep-since, keep-latest-n, or keep-n-per-bucket must be set for the profile policy",
             );
         }
         for path in &self.profile_paths {

--- a/angrr/src/policy/profile.rs
+++ b/angrr/src/policy/profile.rs
@@ -132,9 +132,7 @@ impl ProfilePolicy {
                         );
                 });
 
-                for p in processed_curr {
-                    processed.insert(p);
-                }
+                processed.extend(processed_curr);
             }
         }
 

--- a/angrr/src/policy/profile.rs
+++ b/angrr/src/policy/profile.rs
@@ -1,8 +1,11 @@
+use std::collections::BTreeSet;
 use std::{fs, path::PathBuf};
 
+use crate::{
+    config::KeepNPerBucket, config::ProfileConfig, profile::Generation, profile::Profile,
+    utils::format_duration_short,
+};
 use anyhow::Context;
-
-use crate::{config::ProfileConfig, profile::Profile, utils::format_duration_short};
 
 #[derive(Clone, Debug)]
 pub struct ProfilePolicy {
@@ -90,6 +93,48 @@ impl ProfilePolicy {
                     profile.generations[i].number,
                 );
                 keep_generation[i] = true;
+            }
+        }
+
+        // Retain `n` generations every `bucket-window` duration for `bucket-amount` buckets.
+        let sorted_generations: Vec<(usize, &Generation)> = {
+            let mut vec = profile.generations.iter().enumerate().collect::<Vec<_>>();
+            vec.sort_by_key(|(_idx, generation)| generation.root.age);
+            vec
+        };
+        // Keep track of what was processed and skip them.
+        let mut processed: BTreeSet<usize> = BTreeSet::new();
+        for &KeepNPerBucket {
+            n,
+            bucket_window,
+            bucket_amount,
+        } in &self.config.keep_n_per_bucket
+        {
+            for i in 0..bucket_amount {
+                let mut processed_curr: BTreeSet<usize> = BTreeSet::new();
+                sorted_generations.iter().filter(|(_, generation)| {
+                        let within_window = bucket_window * i <= generation.root.age
+                            && generation.root.age < bucket_window * (i + 1);
+                        let not_processed = !processed.contains(&generation.number);
+                        within_window && not_processed
+                    })
+                    .take(n)
+                    .for_each(|(gen_index, generation)| {
+                        processed_curr.insert(generation.number);
+                        keep_generation[*gen_index] = true;
+                        log::debug!(
+                            "[{}] keep generation {} by keep_n_per_bucket, namely {} generation each bucket spanning {} for {} buckets",
+                            self.name,
+                            &generation.number,
+                            n,
+                            format_duration_short(bucket_window),
+                            bucket_amount,
+                        );
+                });
+
+                for p in processed_curr {
+                    processed.insert(p);
+                }
             }
         }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -137,6 +137,37 @@ See **COMMON POLICY OPTIONS** for common options.
 
     Only useful for system profiles. Default is `false`.
 
+**keep-n-per-bucket** = list of { n: \<usize\>, bucket-window: \<duration\>, bucket-amount: \<u32\> }
+:   Specify a list of rules having `n`, `bucket-window`, and `bucket-amount` attributes.
+
+    Each rule retains `n` generations every `bucket-window` duration for `bucket-amount` buckets.
+    `n` defaults to 1.
+    This can be useful for server configurations such that there will be sparse but available older
+    generations to rollback to.
+
+    This attribute is inspired by the
+    [grandfather-father-son](https://en.wikipedia.org/wiki/Backup_rotation_scheme#Grandfather-father-son)
+    backup scheme.
+
+    Take the configuration `{n = 1; bucket-window = "1 Month"; bucket-amount = 2;}` as an example.
+    Angrr will group past generations into buckets such that each bucket contains generations of the
+    same month (_bucket-window_). It then retains 1 (_n_) most recent generation out of each bucket,
+    for first two buckets (_bucket-amount_).
+
+    Rules are processed in order. `bucket-window` is defined in `humantime::parse_duration`
+    specified in the [DURATION section](#DURATION).
+
+    `bucket-window` is used with regard to the moment angrr is run and doesn't reflect calendar.
+    For example, a period of one week represents the seven days before the run time, not the number
+    of days since the start of the calendar week.
+
+    Rules can have overlapping `bucket-window`. When a generation of a bucket satisfying a rule is already
+    kept by a previous rule, we take the next most recent one of the same bucket and give up if
+    there are no more in the same bucket.
+    In other words: when looking for generations within a bucket that are not yet handled and none
+    are found, we do not look into the next youngest bucket for them.
+    Separate rules for that next bucket will still be applied.
+
 # FILTER OPTIONS
 
 **program** = \<path\>

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
                   nixos-test-service = mkTest ./nixos/tests/angrr.nix;
                   nixos-test-filter = mkTest ./nixos/tests/filter.nix;
                   nixos-test-preset = mkTest ./nixos/tests/preset.nix;
+                  nixos-test-keep-n-per-bucket = mkTest ./nixos/tests/keep-n-per-bucket.nix;
                 }
               )
 

--- a/nixos/tests/keep-n-per-bucket.nix
+++ b/nixos/tests/keep-n-per-bucket.nix
@@ -1,0 +1,119 @@
+{ pkgs, ... }:
+let
+  drvForTest =
+    name:
+    pkgs.runCommand "angrr-test-${name}" { } ''
+      mkdir --parents "$out"
+      echo "${name}" >"$out/${name}"
+    '';
+in
+{
+  name = "angrr-keep-n-per-bucket";
+  nodes = {
+    machine = {
+      services.angrr = {
+        enable = true;
+        logLevel = "debug";
+        settings = {
+          profile-policies = {
+            system = {
+              profile-paths = [ "/nix/var/nix/profiles/system" ];
+              keep-n-per-bucket = [
+                {
+                  bucket-amount = 3;
+                  bucket-window = "7 days";
+                }
+                {
+                  bucket-amount = 2;
+                  bucket-window = "30 days";
+                }
+              ];
+            };
+          };
+        };
+      };
+      # `angrr.service` integrates to `nix-gc.service` by default
+      nix.gc.automatic = true;
+
+      # Create a normal nix user for test
+      users.users.normal.isNormalUser = true;
+      # For `nix build /run/current-system --out-link`,
+      # `nix-build` does not support this use case.
+      nix.settings.experimental-features = [ "nix-command" ];
+
+      # Add some store paths to machine for test
+      environment.etc."drvs-for-test".text = ''
+        ${drvForTest "drv1"}
+        ${drvForTest "drv2"}
+        ${drvForTest "drv3"}
+        ${drvForTest "drv4"}
+        ${drvForTest "drv5"}
+        ${drvForTest "drv6"}
+        ${drvForTest "drv7"}
+        ${drvForTest "drv8"}
+        ${drvForTest "drv9"}
+        ${drvForTest "drv10"}
+        ${drvForTest "drv11"}
+        ${drvForTest "drv12"}
+        ${drvForTest "drv13"}
+        ${drvForTest "drv14"}
+      '';
+
+      # Unit start limit workaround
+      systemd.services.angrr.unitConfig.StartLimitBurst = 10;
+    };
+  };
+
+  testScript = /* python */ ''
+    start_all()
+
+    machine.wait_for_unit("default.target")
+    machine.systemctl("stop nix-gc.timer")
+
+    # Create some GC roots
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv1"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv2"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv3"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv4"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv5"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv6"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv7"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv8"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv9"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv10"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv11"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv12"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv13"}")
+    machine.succeed("date -s '5 days'")
+    machine.succeed("nix-env --profile /nix/var/nix/profiles/system --set ${drvForTest "drv14"}")
+    machine.succeed("date -s '5 days'")
+
+    machine.systemctl("start angrr.service")
+    machine.succeed("readlink /nix/var/nix/profiles/system-14-link") # keep (first of weekly)
+    machine.succeed("readlink /nix/var/nix/profiles/system-13-link") # keep (second of weekly)
+    machine.succeed("readlink /nix/var/nix/profiles/system-12-link") # keep (third of weekly)
+    machine.succeed("readlink /nix/var/nix/profiles/system-11-link") # keep (first of monthly)
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-10-link")
+    machine.succeed("readlink /nix/var/nix/profiles/system-9-link") # keep (second of monthly)
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-8-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-7-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-6-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-5-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-4-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-3-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-2-link")
+    machine.succeed("test ! -e /nix/var/nix/profiles/system-1-link")
+  '';
+}


### PR DESCRIPTION
Hello, this implements the feature I wanted in #47. Closes #47.

It aims to retain 1 generation every `duration` duration for `count` times.
The configuration is a list of rules that are flexible. Order doesn't matter.
For example, the configuration `{count: 4, duration: "1 Month"}` will retain _one_ generation for each of last _four_ months.

All `nix flake check`s pass, and I added a new test checking the profile removal logic.
