### PR TITLE
Fix envvar filtering

### DIFF
--- a/angrr/src/config.rs
+++ b/angrr/src/config.rs
@@ -364,7 +364,7 @@ where
         .merge(
             // Ignore log_style used in main for logging
             // Ignore direnv_log which isn't part of this binary
-            Env::prefixed("ANGRR_").filter(|k| matches!(k.as_str(), "log_style" | "direnv_log")),
+            Env::prefixed("ANGRR_").ignore(&["LOG_STYLE", "DIRENV_LOG"]),
         )
         .extract()?;
     config.validate()?;

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
                   nixos-test-filter = mkTest ./nixos/tests/filter.nix;
                   nixos-test-preset = mkTest ./nixos/tests/preset.nix;
                   nixos-test-keep-n-per-bucket = mkTest ./nixos/tests/keep-n-per-bucket.nix;
+                  nixos-test-validate = mkTest ./nixos/tests/validate.nix;
                 }
               )
 

--- a/nixos/tests/validate.nix
+++ b/nixos/tests/validate.nix
@@ -1,0 +1,25 @@
+{ ... }:
+{
+  name = "angrr-validate";
+  nodes = {
+    machine =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [ pkgs.angrr ];
+      };
+  };
+
+  testScript = /* python */ ''
+    start_all()
+    machine.wait_for_unit("default.target")
+
+    with subtest("generate empty toml"):
+      machine.succeed(":> empty.toml")
+
+    with subtest("should not be affected with LOG_STYLE"):
+      machine.succeed("ANGRR_LOG_STYLE=foo angrr validate -c empty.toml")
+
+    with subtest("should be affected with other stuff"):
+      machine.fail("ANGRR_MEOW_MEOW=foo angrr validate -c empty.toml")
+  '';
+}


### PR DESCRIPTION
Hi, I found a mistake in the PR merged today. Sorry about that, should be fixed with this.

I used `.as_str()` on an `UncasedStr` type, which makes it case sensitive. The filtering predicate also was negated (should've been `!matches!(...)`). Two mistakes canceled out and the tests passed.

Turns out that it's possible to compare `UncasedStr` with `&str` (using `Eq` impl), which is what the `ignore` method does under the hood.