### PR TITLE
Fix clippy warning

### DIFF
--- a/angrr/src/policy/profile.rs
+++ b/angrr/src/policy/profile.rs
@@ -124,7 +124,7 @@ impl ProfilePolicy {
                         log::debug!(
                             "[{}] keep generation {} by keep_n_per_bucket, namely {} generation each bucket spanning {} for {} buckets",
                             self.name,
-                            &generation.number,
+                            generation.number,
                             n,
                             format_duration_short(bucket_window),
                             bucket_amount,


### PR DESCRIPTION
Fix clippy warning:
```
error: Cannot build '/nix/store/03yhdzin6fsq6w17f5il62wkm6qan7n9-angrr-0.2.7.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/70gdd2zv4bkhz52i3cayicnqvcmpln33-angrr-0.2.7
       Last 25 log lines:
       >     Checking rust-embed-utils v8.12.0
       >    Compiling rust-embed-impl v8.12.0
       >     Checking regex v1.13.1
       >     Checking globset v0.4.19
       >     Checking rust-embed v8.12.0
       >     Checking ignore v0.4.30
       >     Checking env_filter v2.0.0
       >     Checking serde_regex v1.2.0
       >     Checking env_logger v0.11.11
       >     Checking toml v0.8.23
       >     Checking figment v0.10.19
       >     Checking angrr v0.2.7 (/build/source/angrr)
       > error: redundant reference in `debug!` argument
       >    --> angrr/src/policy/profile.rs:127:29
       >     |
       > 127 | ...                   &generation.number,
       >     |                       ^^^^^^^^^^^^^^^^^^ help: remove the redundant `&`: `generation.number`
       >     |
       >     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting
       >     = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
       >     = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`
       >
       > error: could not compile `angrr` (lib) due to 1 previous error
       > warning: build failed, waiting for other jobs to finish...
       > error: could not compile `angrr` (lib test) due to 1 previous error
       For full logs, run:
         nix log /nix/store/03yhdzin6fsq6w17f5il62wkm6qan7n9-angrr-0.2.7.drv
```